### PR TITLE
Add permissions for deploy job and force orphan option for GitHub Pages

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -29,6 +29,8 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -46,3 +48,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          force_orphan: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the deployment pipeline to improve GitHub Pages publishing reliability by enabling orphan-branch deployments and ensuring appropriate write permissions.
  - Maintains the existing publish directory, with no changes to site content or structure.
  - Aims to reduce deployment issues and history bloat for cleaner, more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->