### PR TITLE
Update Icon component to use BASE_URL for SVG sprite path

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -8,7 +8,7 @@ type IconProps = {
 export const Icon: React.FC<IconProps> = ({ id, className, size }) => {
   return (
     <svg className={className} height={size} width={size}>
-      <use href={`/svg/sprite.svg#${id}`}></use>
+      <use href={`${import.meta.env.BASE_URL}/svg/sprite.svg#${id}`}></use>
     </svg>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Icons now load reliably across all environments, including deployments under a custom base path or behind a reverse proxy.
  * Resolves cases where icons appeared broken or missing due to incorrect sprite URL resolution.
  * Improves consistency between local development and production, ensuring SVG icons render as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->