### PR TITLE
OSTC-118: fix borders Hero section and burrons

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,6 +1,7 @@
 .button {
   border-radius: 20px;
-  width: 245.5px;
+  width: 100%;
+  max-width: 245.5px;
   height: 64px;
   font-size: 22px;
   display: flex;
@@ -26,4 +27,13 @@
   background-color: transparent;
   border: 2px solid #ff8c00;
   color: #111827;
+}
+
+@media screen and (max-width: 768px) {
+  .button {
+    max-width: 220px;
+    height: 48px;
+    border-radius: 12px;
+    font-size: 16px;
+  }
 }

--- a/src/components/HeroSection/HeroSection.css
+++ b/src/components/HeroSection/HeroSection.css
@@ -61,6 +61,9 @@
 }
 
 @media (max-width: 1024px) {
+  .hero {
+    border-radius: 20px;
+  }
   .hero h1 {
     font-size: 54px;
   }


### PR DESCRIPTION
OSTC-118: fix borders Hero section and burrons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Button now uses a fluid width up to 245.5px for better responsiveness.
  - Improved mobile styling (≤768px): button max-width 220px, height 48px, border radius 12px, and font size 16px for enhanced touch usability.
  - Hero section gains a 20px border radius on tablets (≤1024px) for a more consistent rounded design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->