### PR TITLE
[OSTC-203] Fix CI and format check

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -16,12 +16,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Lint code
         run: npm run lint
       - name: Check code formatting
-        run: npm run format
+        run: npm run format:check
       - name: Run tests
         run: npm test -- --ci --coverage
       - name: Build project
@@ -39,8 +40,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run tests
         run: npm test -- --ci --coverage
       - name: Build project

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview",
     "test": "jest"
   },

--- a/src/components/GenderIcon/GenderIcon.test.tsx
+++ b/src/components/GenderIcon/GenderIcon.test.tsx
@@ -11,7 +11,9 @@ describe('GenderIcon', () => {
 
     expect(getByTestId('icon-male')).toBeInTheDocument();
     expect(container.querySelector('.gender-icon--male')).toBeInTheDocument();
-    expect(container.querySelector('.gender-icon--female')).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.gender-icon--female')
+    ).not.toBeInTheDocument();
   });
 
   test('renders icon-female and applies female modifier class for FEMALE', () => {
@@ -19,6 +21,8 @@ describe('GenderIcon', () => {
 
     expect(getByTestId('icon-female')).toBeInTheDocument();
     expect(container.querySelector('.gender-icon--female')).toBeInTheDocument();
-    expect(container.querySelector('.gender-icon--male')).not.toBeInTheDocument();
+    expect(
+      container.querySelector('.gender-icon--male')
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/GoogleAuthButton/GoogleAuthButton.test.tsx
+++ b/src/components/GoogleAuthButton/GoogleAuthButton.test.tsx
@@ -15,23 +15,31 @@ describe('GoogleAuthButton', () => {
   });
 
   test('renders Google icon', () => {
-    render(<GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />);
+    render(
+      <GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />
+    );
     expect(screen.getByTestId('icon-google')).toBeInTheDocument();
   });
 
   test('calls onClick when clicked', () => {
-    render(<GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />);
+    render(
+      <GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />
+    );
     fireEvent.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   test('has correct aria-label', () => {
-    render(<GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />);
+    render(
+      <GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />
+    );
     expect(screen.getByLabelText('Sign in with Google')).toBeInTheDocument();
   });
 
   test('has type="button" to prevent form submission', () => {
-    render(<GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />);
+    render(
+      <GoogleAuthButton onClick={onClick} ariaLabel="Sign in with Google" />
+    );
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
   });
 });

--- a/src/components/LoginModal/LoginModal.css
+++ b/src/components/LoginModal/LoginModal.css
@@ -154,4 +154,3 @@
 .login-form-register-link:hover {
   text-decoration: none;
 }
-

--- a/src/components/PetDetailCard/PetDetailCard.test.tsx
+++ b/src/components/PetDetailCard/PetDetailCard.test.tsx
@@ -12,7 +12,11 @@ jest.mock('react-i18next', () => ({
 jest.mock('../PetGallery/PetGallery', () => ({
   __esModule: true,
   default: ({ images, altText }: { images: string[]; altText: string }) => (
-    <div data-testid="pet-gallery" data-images-count={images.length} data-alt={altText} />
+    <div
+      data-testid="pet-gallery"
+      data-images-count={images.length}
+      data-alt={altText}
+    />
   ),
 }));
 

--- a/src/components/RegistrationModal/RegistrationModal.css
+++ b/src/components/RegistrationModal/RegistrationModal.css
@@ -168,4 +168,3 @@
 .reg-form-login-link:hover {
   text-decoration: none;
 }
-

--- a/src/pages/PetDetailPage/PetDetailPage.test.tsx
+++ b/src/pages/PetDetailPage/PetDetailPage.test.tsx
@@ -18,7 +18,11 @@ jest.mock('react-i18next', () => ({
 jest.mock('../../components/PetDetailCard/PetDetailCard', () => ({
   __esModule: true,
   default: ({ pet }: { pet: Pet }) => (
-    <div data-testid="pet-detail-card" data-pet-id={pet.id} data-pet-name={pet.name} />
+    <div
+      data-testid="pet-detail-card"
+      data-pet-id={pet.id}
+      data-pet-name={pet.name}
+    />
   ),
 }));
 

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -7,9 +7,7 @@ jest.mock('./api', () => ({
   },
 }));
 
-const mockedPost = apiClient.post as jest.MockedFunction<
-  typeof apiClient.post
->;
+const mockedPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
 
 describe('registerUser', () => {
   beforeEach(() => {
@@ -90,7 +88,11 @@ describe('registerUser', () => {
   });
 
   test('propagates errors from apiClient', async () => {
-    const error = { type: 'client', status: 409, message: 'Email Already Exists' };
+    const error = {
+      type: 'client',
+      status: 409,
+      message: 'Email Already Exists',
+    };
     mockedPost.mockRejectedValueOnce(error);
 
     await expect(


### PR DESCRIPTION
## Summary

  Fix two CI reliability issues:

  - `npm install` in CI ignored the lockfile, so installed deps could drift from what was tested locally. Switched to `npm ci` to enforce exact versions from `package-lock.json`.
  - The "Check code formatting" step ran `prettier --write`, which always exits 0 — formatting was never actually enforced. Switched to `prettier --check` via a new `format:check` script.

  Also added `cache: 'npm'` to `setup-node` in both jobs to reuse the npm download cache between runs (~2-4× faster install step).
