### PR TITLE
[OSTC-204] Add Button action variant, className prop, and CSS fixes

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -2,7 +2,6 @@
   border-radius: 20px;
   width: 100%;
   max-width: var(--btn-max-width);
-  max-height: var(--btn-max-height);
   height: var(--btn-height);
   font-size: 22px;
   font-weight: 800;
@@ -38,16 +37,18 @@
   cursor: not-allowed;
 }
 
-.button:disabled:hover {
-  background-color: var(--btn-primary-bg);
+.button--secondary:disabled:hover {
   box-shadow: none;
+}
+
+.button--primary:disabled:hover {
+  background-color: var(--btn-primary-bg);
 }
 
 @media screen and (max-width: 768px) {
   .button {
     max-width: var(--btn-max-width-mobile, var(--btn-max-width));
-    max-height: var(--btn-max-height-mobile, var(--btn-max-height));
-    height: 48px;
+    height: var(--btn-height-mobile, 48px);
     border-radius: 12px;
     font-size: 16px;
   }

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,9 +1,3 @@
-:root {
-  --color-primary: #ff7300;
-  --color-primary-hover: #ff8c00;
-  --color-text-dark: #595c6e;
-}
-
 .button {
   border-radius: 20px;
   width: 100%;
@@ -21,22 +15,22 @@
 }
 
 .button--primary:hover {
-  background-color: var(--color-primary-hover);
+  background-color: var(--btn-primary-bg-hover);
   border: none;
 }
 
 .button--secondary:hover {
-  box-shadow: 0px 1px 8px 0px var(--color-primary);
+  box-shadow: 0px 1px 8px 0px var(--btn-primary-bg);
 }
 
 .button--primary {
-  background-color: var(--color-primary);
+  background-color: var(--btn-primary-bg);
   color: white;
 }
 .button--secondary {
   background-color: transparent;
-  border: 2px solid var(--color-primary);
-  color: var(--color-text-dark);
+  border: 2px solid var(--btn-primary-bg);
+  color: var(--btn-secondary-text);
 }
 
 .button:disabled {
@@ -45,7 +39,7 @@
 }
 
 .button:disabled:hover {
-  background-color: var(--color-primary);
+  background-color: var(--btn-primary-bg);
   box-shadow: none;
 }
 

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -32,6 +32,18 @@
   color: var(--btn-secondary-text);
 }
 
+.button--action {
+  background-color: var(--btn-action-bg);
+  color: #ffffff;
+  border-radius: 8px;
+  font-family: var(--font-secondary);
+  font-size: 16px;
+}
+
+.button--action:hover {
+  background-color: var(--btn-action-bg-hover);
+}
+
 .button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
@@ -45,11 +57,19 @@
   background-color: var(--btn-primary-bg);
 }
 
+.button--action:disabled:hover {
+  background-color: var(--btn-action-bg);
+}
+
 @media screen and (max-width: 768px) {
   .button {
     max-width: var(--btn-max-width-mobile, var(--btn-max-width));
     height: var(--btn-height-mobile, 48px);
     border-radius: 12px;
     font-size: 16px;
+  }
+
+  .button--action {
+    border-radius: 8px;
   }
 }

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -2,34 +2,110 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import Button from './Button';
 
 describe('Button Component', () => {
-  test('renders button with children', () => {
-    render(<Button>Click me</Button>);
-    expect(screen.getByText('Click me')).toBeInTheDocument();
+  describe('rendering', () => {
+    test('renders button with children', () => {
+      render(<Button>Click me</Button>);
+      expect(screen.getByText('Click me')).toBeInTheDocument();
+    });
+
+    test('always includes base button class', () => {
+      render(<Button>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button).toHaveClass('button');
+    });
   });
 
-  test('applies primary variant class when no variant is specified', () => {
-    render(<Button>Click me</Button>);
-    const button = screen.getByText('Click me');
-    expect(button).toHaveClass('button--primary');
+  describe('variants', () => {
+    test('applies primary variant class when no variant is specified', () => {
+      render(<Button>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button).toHaveClass('button--primary');
+    });
+
+    test('applies secondary variant class when variant is secondary', () => {
+      render(<Button variant="secondary">Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button).toHaveClass('button--secondary');
+    });
+
+    test('applies action variant class when variant is action', () => {
+      render(<Button variant="action">Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button).toHaveClass('button--action');
+    });
   });
 
-  test('applies secondary variant class when variant is secondary', () => {
-    render(<Button variant="secondary">Click me</Button>);
-    const button = screen.getByText('Click me');
-    expect(button).toHaveClass('button--secondary');
+  describe('className prop', () => {
+    test('renders without extra classes when className is not provided', () => {
+      render(<Button>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.className).toBe('button button--primary');
+    });
+
+    test('appends className after variant classes', () => {
+      render(<Button className="custom-layout">Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.className).toBe('button button--primary custom-layout');
+    });
+
+    test('supports multiple classes in className prop', () => {
+      render(
+        <Button variant="secondary" className="mt-4 self-end">
+          Click me
+        </Button>
+      );
+      const button = screen.getByText('Click me');
+      expect(button.className).toBe('button button--secondary mt-4 self-end');
+    });
   });
 
-  test('calls onClick handler when button is clicked', () => {
-    const handleClick = jest.fn();
-    render(<Button onClick={handleClick}>Click me</Button>);
-    const button = screen.getByText('Click me');
-    fireEvent.click(button);
-    expect(handleClick).toHaveBeenCalledTimes(1);
+  describe('interactions', () => {
+    test('calls onClick handler when button is clicked', () => {
+      const handleClick = jest.fn();
+      render(<Button onClick={handleClick}>Click me</Button>);
+      const button = screen.getByText('Click me');
+      fireEvent.click(button);
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
   });
 
-  test('always includes base button class', () => {
-    render(<Button>Click me</Button>);
-    const button = screen.getByText('Click me');
-    expect(button).toHaveClass('button');
+  describe('size CSS variables (regression guards)', () => {
+    test('sets --btn-height CSS variable from height prop', () => {
+      render(<Button height={80}>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.style.getPropertyValue('--btn-height')).toBe('80px');
+    });
+
+    test('sets --btn-height-mobile CSS variable from heightMobile prop', () => {
+      render(<Button heightMobile={64}>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.style.getPropertyValue('--btn-height-mobile')).toBe('64px');
+    });
+
+    test('sets --btn-max-width CSS variable from maxWidth prop', () => {
+      render(<Button maxWidth={200}>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.style.getPropertyValue('--btn-max-width')).toBe('200px');
+    });
+
+    test('sets --btn-max-width-mobile CSS variable from maxWidthMobile prop', () => {
+      render(<Button maxWidthMobile={150}>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.style.getPropertyValue('--btn-max-width-mobile')).toBe(
+        '150px'
+      );
+    });
+
+    test('supports string values for size props', () => {
+      render(<Button height="3rem">Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.style.getPropertyValue('--btn-height')).toBe('3rem');
+    });
+
+    test('does not set CSS variable when size prop is not provided', () => {
+      render(<Button>Click me</Button>);
+      const button = screen.getByText('Click me');
+      expect(button.style.getPropertyValue('--btn-height')).toBe('');
+    });
   });
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,6 +16,11 @@ interface ButtonProps {
   style?: React.CSSProperties;
   type?: 'button' | 'submit';
   disabled?: boolean;
+  /**
+   * Optional layout-only className. Do NOT use for colors, backgrounds,
+   * borders, or typography — those must come from variants and design tokens.
+   */
+  className?: string;
 }
 
 const toPx = (v?: number | string) => (typeof v === 'number' ? `${v}px` : v);
@@ -31,6 +36,7 @@ const Button: React.FC<ButtonProps> = ({
   style,
   type = 'button',
   disabled = false,
+  className,
 }) => {
   const cssVars = {
     '--btn-max-width': toPx(maxWidth) ?? undefined,
@@ -44,7 +50,7 @@ const Button: React.FC<ButtonProps> = ({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`button button--${variant}`}
+      className={`button button--${variant}${className ? ` ${className}` : ''}`}
       style={{ ...cssVars, ...style }}
     >
       {children}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 import './Button.css';
 
-type ButtonVariant = 'primary' | 'secondary';
+type ButtonVariant = 'primary' | 'secondary' | 'action';
 
 interface ButtonProps {
   children: ReactNode;

--- a/src/components/LoginModal/LoginModal.css
+++ b/src/components/LoginModal/LoginModal.css
@@ -121,19 +121,6 @@
   text-decoration: underline;
 }
 
-.login-form .button {
-  border-radius: 6px;
-  font-family: var(--font-secondary);
-  font-size: 16px;
-  font-weight: 800;
-  background-color: #0054d6;
-  color: #ffffff;
-}
-
-.login-form .button:hover {
-  background-color: #153da8;
-}
-
 .login-form-register-text {
   text-align: center;
   font-family: var(--font-primary);

--- a/src/components/LoginModal/LoginModal.tsx
+++ b/src/components/LoginModal/LoginModal.tsx
@@ -149,7 +149,7 @@ const LoginModal: React.FC<LoginModalProps> = ({
         )}
         <Button
           type="submit"
-          variant="primary"
+          variant="action"
           maxWidth="100%"
           height={56}
           disabled={isSubmitting}

--- a/src/components/RegistrationModal/RegistrationModal.css
+++ b/src/components/RegistrationModal/RegistrationModal.css
@@ -114,20 +114,6 @@
   fill: var(--title-color-dark);
 }
 
-.reg-form .button {
-  border-radius: 6px;
-  font-family: var(--font-secondary);
-  font-size: 16px;
-  font-weight: 800;
-  background-color: #0054d6;
-
-  color: #ffffff;
-}
-
-.reg-form .button:hover {
-  background-color: #153da8;
-}
-
 .reg-form-hint {
   display: flex;
   align-items: center;

--- a/src/components/RegistrationModal/RegistrationModal.tsx
+++ b/src/components/RegistrationModal/RegistrationModal.tsx
@@ -210,7 +210,7 @@ const RegistrationModal: React.FC<RegistrationModalProps> = ({
           )}
           <Button
             type="submit"
-            variant="primary"
+            variant="action"
             maxWidth="100%"
             height={56}
             disabled={isSubmitting}

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,11 @@
   --button-text: #ffffff;
   --container-padding: 40px;
 
+  /* Button colors */
+  --btn-primary-bg: #ff7300;
+  --btn-primary-bg-hover: #ff8c00;
+  --btn-secondary-text: #091a49;
+
   font-family: var(--font-primary);
   line-height: 1.5;
   font-weight: 400;

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,8 @@
   --btn-primary-bg: #ff7300;
   --btn-primary-bg-hover: #ff8c00;
   --btn-secondary-text: #091a49;
+  --btn-action-bg: #0054d6;
+  --btn-action-bg-hover: #153da8;
 
   font-family: var(--font-primary);
   line-height: 1.5;


### PR DESCRIPTION
 ## Summary

  Login and registration forms restyled Button via descendant selectors (`.login-form .button`, `.reg-form .button`) — two identical blocks with hardcoded `#0054d6`. Breaks encapsulation,
  duplicates styles; the upcoming reset password form would become a third copy.

  Adds a semantic `action` variant and `className` prop to Button, migrates both forms, and fixes three defects surfaced during audit